### PR TITLE
Root trace point should collect full duration of imports

### DIFF
--- a/profimp/main.py
+++ b/profimp/main.py
@@ -47,7 +47,8 @@ def print_help():
 def trace_module(import_line):
     root_pt = tracer.init_stack()
     with tracer.patch_import():
-        exec(import_line)
+        with root_pt:
+            exec(import_line)
     return root_pt
 
 


### PR DESCRIPTION
It's very simple to make root point collect duration of all operation
this change does this
