### PR TITLE
Add package installation command to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Installation of profimp is super easy:
 .. code-block::
 
     git clone https://github.com/boris-42/profimp && cd profimp
-    pip install -r requirements.txt
+    sudo python setup.py install
 
 
 Usage


### PR DESCRIPTION
Command for installation profimp python package is missed from
'Installation' section of README file. This is fix for this issue.
