### PR TITLE
Optimize profimp imports

### DIFF
--- a/profimp/reports.py
+++ b/profimp/reports.py
@@ -13,9 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import json
-import os
-
 
 def _normalize(results, started_at=None):
     started_at = started_at or results["started_at"]
@@ -30,10 +27,13 @@ def _normalize(results, started_at=None):
 
 
 def to_json(results):
+    import json
     return json.dumps(_normalize(results.to_dict()), indent=2)
 
 
 def to_html(results):
+    import os
+
     template_path = os.path.join(
         os.path.dirname(__file__), "templates", "report.tpl")
 

--- a/profimp/tracer.py
+++ b/profimp/tracer.py
@@ -13,8 +13,6 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-
-import contextlib
 import sys
 import time
 
@@ -80,12 +78,14 @@ def init_stack():
     return TRACE_STACK[0]
 
 
-@contextlib.contextmanager
-def patch_import():
-    old_import = builtins.__import__
-    builtins.__import__ = _traceit(builtins.__import__)
-    yield
-    builtins.__import__ = old_import
+class patch_import(object):
+
+    def __enter__(self):
+        self.old_import = builtins.__import__
+        builtins.__import__ = _traceit(builtins.__import__)
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        builtins.__import__ = self.old_import
 
 
 def _traceit(f):


### PR DESCRIPTION
Import os and json inside the reports to_json and to_html methods
so now you can trace with profimp "json" and "re" libs

Remove contextlib import at all (use class as context manager)
